### PR TITLE
Fix improperly formatted heading in midi guide

### DIFF
--- a/docs/guides/midi.md
+++ b/docs/guides/midi.md
@@ -42,6 +42,7 @@ There will be another guide for assembly later.
     - Threaded inserts
 14. Diodes (for your switch matrix)
 15. Resistors and capacitors (specify in the submission form!)
+
 ## Getting started
 This guide covers the essential steps needed to make a simple mini device, and teaches you to implement the folowing things in both circuit design and code.
 - Switches and keys (in matrix)


### PR DESCRIPTION
# Bug
The current site's midi guide page has an improperly formatted heading.

<img width="881" height="282" alt="image" src="https://github.com/user-attachments/assets/73a2ec73-d28b-4deb-8a5f-16dd9787f727" />
<img width="886" height="94" alt="image" src="https://github.com/user-attachments/assets/edd6020a-b043-4dad-82c4-f7206878f6f4" />

# Fix
This is the fixed version. I added a blank line before the relevant h2 in `docs/guide/midi.md`.

<img width="921" height="469" alt="image" src="https://github.com/user-attachments/assets/f5adf412-56b4-4e5a-bf1b-65cf510f1245" />
